### PR TITLE
Add support for markdown and word count

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,497 +1,538 @@
+Version 2.3.0 (05/19/2025)
+
+- Add Markdown output mode (-M).
+  - Produces a standard Markdown bulleted list.
+  - Uses indentation to represent tree hierarchy.
+  - Compatible with metadata flags (-p, -s, -u, -g, -D, --inodes, --device).
+  - Integrates with word count (-w) and size reporting (--du) in summary.
+  - Mutually exclusive with XML (-X), JSON (-J), and HTML (-H) outputs.
+- Add word count feature (-w).
+  - Displays word count for files (heuristically skips binary files).
+  - Sets word count to 0 for directories.
+  - Word count info displayed in standard output and summary reports (standard, HTML, JSON, XML, Markdown).
+
 Version 2.2.1 (11/25/2024)
-  - Yet another brown-paper bag release.  I seem to like doing these.
-  - Fix regression where I free a pointer that should not have been freed due
-    to a variable renaming that wasn't completed. (Daniel Li / Landon Bourma)
-  - Put back, in a modified form, HTML href directory path fixing that was
-    removed in 2.1.2. If the "baseHREF" part after the -H begins with a dash
-    (-), the dash is removed and the lead directory name is removed from the
-    href, otherwise it is left as-is.  It can be very difficult to know how to
-    handle the host and directory part given the plethora of protocols and
-    what-not, so hopefully this should give enough control over that to suit
-    most requirements.
+
+- Yet another brown-paper bag release. I seem to like doing these.
+- Fix regression where I free a pointer that should not have been freed due
+  to a variable renaming that wasn't completed. (Daniel Li / Landon Bourma)
+- Put back, in a modified form, HTML href directory path fixing that was
+  removed in 2.1.2. If the "baseHREF" part after the -H begins with a dash
+  (-), the dash is removed and the lead directory name is removed from the
+  href, otherwise it is left as-is. It can be very difficult to know how to
+  handle the host and directory part given the plethora of protocols and
+  what-not, so hopefully this should give enough control over that to suit
+  most requirements.
 
 Version 2.2.0 (11/24/2024)
-  - Add option --opt-toggle which turns on the ability to toggle options such
-    as -a, -p, etc.  Useful to add to an alias for turning an option off when
-    using said alias. (Christoph Anton Mitterer)
-  - Add --hyperlink option to print OSC 8 terminal hyperlinks for files. Also
-    adds the --scheme and --authority options to modify the schema and hostname/
-    authority of the links. (Nicolai Dagestad)
-    OSC 8 Terminal hyperlinks:
-      https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-  - Maybe finally fix JSON error reporting when unable to open a directory and a
-    full tree is required, such as when using --du. (Alchemyst@github)
-  - Fix small rounding error in human readable size (-h) output, where 9.99K is
-    rounded to 10.0K rather than 10K (Ivan Ivanovich)
-  - Fix the totals report for sizes when --du option is used.  The directory
-    size total was correct, but the final report was an accumulation of all
-    the directory totals rather than just the top most directory total.
-    (Alchemyst@github)
-  - Add .gitignore file to distribution for those wanting that. (Kenta Arai)
-  - Add 'none' as a valid --sort option (i.e. -U).
-  - Add ability to cross compile for Android (freemedom@github)
-  - List charsets again if --charsets is not given an argument.
-  - Allow --help and usage to use ANSI bold and italic if colorization is
-    enabled.
-  - General code cleanups:
-    - Removed unused externs where possible.
-    - Clean up some warnings issued by -Wextra (Kenta Arai)
-    - Update Makefile to allow CC and the CFLAGS -O3 option to be overridden,
-      move CPPFLAGS into their own variable, add -Wstrict-prototypes
-      (David Seifert)
-    - Long over-due move to stdbool.h, removes custom bool type and changes all
-      occurrences of TRUE/FALSE to true/false. (David Seifert / others)  This
-      likely makes C99+ even more of a requirement now. Please let me know if
-      this requires a work-around for your system.
-    - Went ahead and added -Wconversion to the Makefile as well. This required a
-      large number of type conversion fixing which may have unexpected side
-      effects, but should hopefully help with tree safely dealing with absurd
-      sizes/number of things in the future as this promotes using size_t more.
-      This probably needs more work to do properly however.
-    - Apply the const constraint on parameter strings wherever possible.
+
+- Add option --opt-toggle which turns on the ability to toggle options such
+  as -a, -p, etc. Useful to add to an alias for turning an option off when
+  using said alias. (Christoph Anton Mitterer)
+- Add --hyperlink option to print OSC 8 terminal hyperlinks for files. Also
+  adds the --scheme and --authority options to modify the schema and hostname/
+  authority of the links. (Nicolai Dagestad)
+  OSC 8 Terminal hyperlinks:
+  https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+- Maybe finally fix JSON error reporting when unable to open a directory and a
+  full tree is required, such as when using --du. (Alchemyst@github)
+- Fix small rounding error in human readable size (-h) output, where 9.99K is
+  rounded to 10.0K rather than 10K (Ivan Ivanovich)
+- Fix the totals report for sizes when --du option is used. The directory
+  size total was correct, but the final report was an accumulation of all
+  the directory totals rather than just the top most directory total.
+  (Alchemyst@github)
+- Add .gitignore file to distribution for those wanting that. (Kenta Arai)
+- Add 'none' as a valid --sort option (i.e. -U).
+- Add ability to cross compile for Android (freemedom@github)
+- List charsets again if --charsets is not given an argument.
+- Allow --help and usage to use ANSI bold and italic if colorization is
+  enabled.
+- General code cleanups:
+  - Removed unused externs where possible.
+  - Clean up some warnings issued by -Wextra (Kenta Arai)
+  - Update Makefile to allow CC and the CFLAGS -O3 option to be overridden,
+    move CPPFLAGS into their own variable, add -Wstrict-prototypes
+    (David Seifert)
+  - Long over-due move to stdbool.h, removes custom bool type and changes all
+    occurrences of TRUE/FALSE to true/false. (David Seifert / others) This
+    likely makes C99+ even more of a requirement now. Please let me know if
+    this requires a work-around for your system.
+  - Went ahead and added -Wconversion to the Makefile as well. This required a
+    large number of type conversion fixing which may have unexpected side
+    effects, but should hopefully help with tree safely dealing with absurd
+    sizes/number of things in the future as this promotes using size_t more.
+    This probably needs more work to do properly however.
+  - Apply the const constraint on parameter strings wherever possible.
 
 Version 2.1.3 (07/09/2024)
-  - Mostly a brown-paper bag release to fix the below regression and add a
-    feature I forgot to add.
-  - Fix regression in search() function that broke --fromfile (Florian Ernst)
-    (caused by removing too much code while fixing premature sort for
-    --fromfile)
-  - Allow the -L option to accept its parameter immediately (with no space)
-    instead of requiring it be the next option word. (Trevor Gross)
+
+- Mostly a brown-paper bag release to fix the below regression and add a
+  feature I forgot to add.
+- Fix regression in search() function that broke --fromfile (Florian Ernst)
+  (caused by removing too much code while fixing premature sort for
+  --fromfile)
+- Allow the -L option to accept its parameter immediately (with no space)
+  instead of requiring it be the next option word. (Trevor Gross)
 
 Version 2.1.2 (07/01/2024)
-  - Fix issue where --gitignore does not think a pattern with a singular
-    terminal '/' (indicating it matches only directories,) is a relative path.
-    (Clinton)
-  - Don't emit the error 'recursive, not followed' if when using -L, the depth
-    would prevent descending anyway. This also fixes up a JSON output error 
-    (missing comma) when this happens. (simonpmind)
-  - Don't prematurely sort files/directories with --from*file. (gitlab @jack6th)
-  - Various seg-faults fixed (Hanqin Guan (The OSLab of Peking University)):
-    - Make doubly sure that there is actually a previous path entry when reading
-      from a tabbed file.
-    - Make sure there is actually a file entity when applying the link info to
-      it when reading fromfile using --fflinks.
-    - Increase space for the path a little in listdir(), just to be sure.
-    - Make sure that there is no topsort (--dirsfirst / --filesfirst) if there
-      is no basesort (-U).
-    - Make sure gittrim() function can handle a null string.
-  - Update email address to steve.baker.llc@gmail.com from ice@mama.indstate.edu
-    which has been permanently disabled.
+
+- Fix issue where --gitignore does not think a pattern with a singular
+  terminal '/' (indicating it matches only directories,) is a relative path.
+  (Clinton)
+- Don't emit the error 'recursive, not followed' if when using -L, the depth
+  would prevent descending anyway. This also fixes up a JSON output error
+  (missing comma) when this happens. (simonpmind)
+- Don't prematurely sort files/directories with --from\*file. (gitlab @jack6th)
+- Various seg-faults fixed (Hanqin Guan (The OSLab of Peking University)):
+  - Make doubly sure that there is actually a previous path entry when reading
+    from a tabbed file.
+  - Make sure there is actually a file entity when applying the link info to
+    it when reading fromfile using --fflinks.
+  - Increase space for the path a little in listdir(), just to be sure.
+  - Make sure that there is no topsort (--dirsfirst / --filesfirst) if there
+    is no basesort (-U).
+  - Make sure gittrim() function can handle a null string.
+- Update email address to steve.baker.llc@gmail.com from ice@mama.indstate.edu
+  which has been permanently disabled.
 
 Version 2.1.1 (05/31/2023)
-  - Various spelling corrections.
-  - Fix issue where following links while doing JSON output would lead to
-    incorrect JSON output. (simonpmind)
-  - Fix issue where .info patterns relative to the .info file that did not use
-    a wildcard for matching the prefix were not matching files properly.
-    (German Lashevich)
-  - Added support for making trees from tab indented files (--fromtabfile)
-    (gitlab @AvidSeeker), also cleaned up some other issues in the fromfile
-    code.
-  - Fix buffer overflow in listdir() when file names are allowed to be longer
-    than 256 characters (like when using fromfile.) (Javier Jaramago Fernández)
-  - If when attempting to open a .gitignore or .info file from a top level
-    directory and failing, recursively check the parents for such a file.  This
-    stops when successful at opening such a file. This behavior might in the
-    future be modified to open all such files in all parents to until root is
-    reached. (Damien Bezborodov) Note that this requires the use of realpath()
-    which I think may be an issue for some OSes.
-  - Fix issue where tree would never descend (-l) a symbolic link when a full
-    tree is gathered (--du/matchdirs/prune) (gitlab @6ramr)
+
+- Various spelling corrections.
+- Fix issue where following links while doing JSON output would lead to
+  incorrect JSON output. (simonpmind)
+- Fix issue where .info patterns relative to the .info file that did not use
+  a wildcard for matching the prefix were not matching files properly.
+  (German Lashevich)
+- Added support for making trees from tab indented files (--fromtabfile)
+  (gitlab @AvidSeeker), also cleaned up some other issues in the fromfile
+  code.
+- Fix buffer overflow in listdir() when file names are allowed to be longer
+  than 256 characters (like when using fromfile.) (Javier Jaramago Fernández)
+- If when attempting to open a .gitignore or .info file from a top level
+  directory and failing, recursively check the parents for such a file. This
+  stops when successful at opening such a file. This behavior might in the
+  future be modified to open all such files in all parents to until root is
+  reached. (Damien Bezborodov) Note that this requires the use of realpath()
+  which I think may be an issue for some OSes.
+- Fix issue where tree would never descend (-l) a symbolic link when a full
+  tree is gathered (--du/matchdirs/prune) (gitlab @6ramr)
 
 Version 2.1.0 (12/26/2022)
-  This is a bit bigger release, due to not realizing that gitlab/github was
-  not sending me email and ice+tree@mama.indstate.edu was broken.  This has
-  been fixed and I think I have gone through most all of the outstanding issues
-  that were submitted over the last few months.  Note to those that are sending
-  me git merge requests: because I distribute this in multiple ways and places,
-  and I tend to manually go over patches and often re-work them in any event, I
-  will not likely ever directly accept any merge requests. I will still use the
-  patch information from them for inclusion into the code, so you are more than
-  welcome to still submit such merges.
-  - Add support for --info and --gitignore for the --fromfile option.
-    (Suggested by Piotr Andruszkow)
-  - Add options --infofile and --gitfile to load .info and .gitignore files
-    explicitly.  Each implies --info or --gitignore respectively.
-  - Add NULL guard for json_printinfo() and xml_printinfo() (and fix ftype
-    printing for XML) (Kenta Arai)
-  - Fix getcharset() to not return a getenv() pointer (fix for ENV34-C issue.)
-    (Kenta Arai)
-  - Another attempt at fixing extraneous /'s in HTML URLs/output. (Sebastian
-    Rose)
-  - Fixed XML output (Dave Rice)
-  - Remove the (very outdated) French version of the manpage.  Look to
-    localization projects such as Debian's 'manpages-l10n' for localized
-    translations. (hmartink)
-  - Add support for the NO_COLOR environment variable (https://no-color.org/).
-    Equivalent to the -n option (can be still be overridden with -C).
-    (Timm Fitschen)
-  - Removed many C99isms to enable compiling on C90 compilers with fewer
-    warnings.  (Sith Wijesinghe and Matthew Sessions)  It should not be
-    necessary to avoid using a standard that is old enough to drink,
-    furthermore it is all but impossible to remove the remaining warnings and
-    have modern features like compound literals. In the meantime I've added
-    -std=c11 to the default CFLAGS for Linux and will likely not worry about
-    C90 compatibility going forward unless there is some other reason for it.
-  - Added a helper function for long command line arguments to clean up option
-    processing (and fixes the processing for a few of the options such as
-    --timefmt= (наб?).)
-  - Added --hintro and --houtro options to select files to use as the HTML
-    intro and outro.  Use /dev/null or an empty file to eliminate them
-    entirely.  This should make it much easier to create your own custom CSS
-    or embed one or more trees into a web page.
-  - Defer printing the version until the character set is known so we can use
-    the linedraw copyright symbol.
-  - Revert change to the error code to not return an error (code 2) when
-    attempting to list a non-directory that actually exists.  Tree will still
-    return an error when attempting to list a non-existing directory/file.
-  - Added option --fflinks which will process symbolic link information from
-    a file generated with 'tree -if --noreport' when using --fromfile.
-    (Suggested by Chentao Credungtao)
-  - Updated the totals reporting code to also include in the total the file or
-    directory that is being listed.  This should make a correct report when
-    doing something like 'tree *'.
+This is a bit bigger release, due to not realizing that gitlab/github was
+not sending me email and ice+tree@mama.indstate.edu was broken. This has
+been fixed and I think I have gone through most all of the outstanding issues
+that were submitted over the last few months. Note to those that are sending
+me git merge requests: because I distribute this in multiple ways and places,
+and I tend to manually go over patches and often re-work them in any event, I
+will not likely ever directly accept any merge requests. I will still use the
+patch information from them for inclusion into the code, so you are more than
+welcome to still submit such merges.
+
+- Add support for --info and --gitignore for the --fromfile option.
+  (Suggested by Piotr Andruszkow)
+- Add options --infofile and --gitfile to load .info and .gitignore files
+  explicitly. Each implies --info or --gitignore respectively.
+- Add NULL guard for json_printinfo() and xml_printinfo() (and fix ftype
+  printing for XML) (Kenta Arai)
+- Fix getcharset() to not return a getenv() pointer (fix for ENV34-C issue.)
+  (Kenta Arai)
+- Another attempt at fixing extraneous /'s in HTML URLs/output. (Sebastian
+  Rose)
+- Fixed XML output (Dave Rice)
+- Remove the (very outdated) French version of the manpage. Look to
+  localization projects such as Debian's 'manpages-l10n' for localized
+  translations. (hmartink)
+- Add support for the NO_COLOR environment variable (https://no-color.org/).
+  Equivalent to the -n option (can be still be overridden with -C).
+  (Timm Fitschen)
+- Removed many C99isms to enable compiling on C90 compilers with fewer
+  warnings. (Sith Wijesinghe and Matthew Sessions) It should not be
+  necessary to avoid using a standard that is old enough to drink,
+  furthermore it is all but impossible to remove the remaining warnings and
+  have modern features like compound literals. In the meantime I've added
+  -std=c11 to the default CFLAGS for Linux and will likely not worry about
+  C90 compatibility going forward unless there is some other reason for it.
+- Added a helper function for long command line arguments to clean up option
+  processing (and fixes the processing for a few of the options such as
+  --timefmt= (наб?).)
+- Added --hintro and --houtro options to select files to use as the HTML
+  intro and outro. Use /dev/null or an empty file to eliminate them
+  entirely. This should make it much easier to create your own custom CSS
+  or embed one or more trees into a web page.
+- Defer printing the version until the character set is known so we can use
+  the linedraw copyright symbol.
+- Revert change to the error code to not return an error (code 2) when
+  attempting to list a non-directory that actually exists. Tree will still
+  return an error when attempting to list a non-existing directory/file.
+- Added option --fflinks which will process symbolic link information from
+  a file generated with 'tree -if --noreport' when using --fromfile.
+  (Suggested by Chentao Credungtao)
+- Updated the totals reporting code to also include in the total the file or
+  directory that is being listed. This should make a correct report when
+  doing something like 'tree \*'.
 
 Version 2.0.4 (09/06/2022)
-  - Brown paper bag release:
-    - Fix missing comma in JSON output. (jogbear?)
+
+- Brown paper bag release:
+  - Fix missing comma in JSON output. (jogbear?)
 
 Version 2.0.3 (08/26/2022)
-  - Fix segfault when filelimit is used and tree encounters a directory it
-    cannot enter. (Kenta Arai)
-  - Use += when assigning CFLAGS and LDFLAGS in the Makefile allowing
-    them to be modified by environment variables during make. (Ben Brown)
-    Possibly assumes GNU make.
-  - Fixed broken -x option (stops recursing.) (balping)
-  - Fix use after free (causing segfault) for dir/subdir in list.c (Erik
-    Skultety / Ben Brown)
-  - Fixes for .gitignore functionality (Saniya Maheshwari / Mig-hub ? / Carlos
-    Pinto)
-    - Fixed * handing in patmatch. Worked almost like ** before, now properly
-      stops at /'s.  These issues were the result of forgetting that patmatch()
-      was just to match filenames to patterns, not paths.
-    - Patterns starting with / are actually relative to the .gitignore file,
-      not the root of the filesystem, go figure.
-    - Patterns without /'s in .gitignore apply to any file in any directory
-      under the .gitignore, not just the .gitignore directory
-  - Remove "All rights reserved" from copyright statements.  A left-over from
-    trees original artistic license.
-  - Add in --du and --prune to --help output (Nxueyamao?)
-  - Fixed segfault when an unknown directory is given with -X
-  - Fixed output up for -X and -J options.
-  - Remove one reference to strnlen which isn't necessary since it may not
-    be available on some OS's.
+
+- Fix segfault when filelimit is used and tree encounters a directory it
+  cannot enter. (Kenta Arai)
+- Use += when assigning CFLAGS and LDFLAGS in the Makefile allowing
+  them to be modified by environment variables during make. (Ben Brown)
+  Possibly assumes GNU make.
+- Fixed broken -x option (stops recursing.) (balping)
+- Fix use after free (causing segfault) for dir/subdir in list.c (Erik
+  Skultety / Ben Brown)
+- Fixes for .gitignore functionality (Saniya Maheshwari / Mig-hub ? / Carlos
+  Pinto)
+  - Fixed \* handing in patmatch. Worked almost like \*\* before, now properly
+    stops at /'s. These issues were the result of forgetting that patmatch()
+    was just to match filenames to patterns, not paths.
+  - Patterns starting with / are actually relative to the .gitignore file,
+    not the root of the filesystem, go figure.
+  - Patterns without /'s in .gitignore apply to any file in any directory
+    under the .gitignore, not just the .gitignore directory
+- Remove "All rights reserved" from copyright statements. A left-over from
+  trees original artistic license.
+- Add in --du and --prune to --help output (Nxueyamao?)
+- Fixed segfault when an unknown directory is given with -X
+- Fixed output up for -X and -J options.
+- Remove one reference to strnlen which isn't necessary since it may not
+  be available on some OS's.
 
 Version 2.0.2 (02/16/2022)
-  - Okay, apparently the stddata addition is causing havoc (who knew how many
-    scripts just haphazardly hand programs random file descriptors, that's
-    surely not a problem.)  Going forward the stddata option will only work
-    if the environment variable STDDATA_FD is present or set to the descriptor
-    to produce the JSON output on.
-  - Fix HTML url output issue. (Maxim Cournoyer)  It was definitely broken in
-    the 2.0.0 release, and this should normalize it with respect to older
-    versions, however I think it needs to be updated to work better.
-  - Update MANPATH for OS X (Michiel Beijen)
-  - Fixed an error with * in the patchmatch code where *foo*bar would match
-    *foo alone. (Josey Smith)
+
+- Okay, apparently the stddata addition is causing havoc (who knew how many
+  scripts just haphazardly hand programs random file descriptors, that's
+  surely not a problem.) Going forward the stddata option will only work
+  if the environment variable STDDATA_FD is present or set to the descriptor
+  to produce the JSON output on.
+- Fix HTML url output issue. (Maxim Cournoyer) It was definitely broken in
+  the 2.0.0 release, and this should normalize it with respect to older
+  versions, however I think it needs to be updated to work better.
+- Update MANPATH for OS X (Michiel Beijen)
+- Fixed an error with * in the patchmatch code where *foo*bar would match
+  *foo alone. (Josey Smith)
 
 Version 2.0.1 (01/03/2022)
-  - Simplify Makefile and the following changes: prefix -> PREFIX,
-    BINDIR -> DESTDIR, -O4 -> -O3, mode 644 for man page installation
-    (Michal Vasilek)
-  - Make patterns ending in '/' match directories (but not files) for -I / -P
-    (Michiel Beijen) should also fix issues with --gitignore as well
-    (Taylor Faubion)
-  - Fix --gitignore not matching files relative to the path of the .gitignore
-    (Taylor Faubion)  I did say it was hacked together.
-  - Refactored color.c a bit to simplify the code as a prelude to meta coloring.
+
+- Simplify Makefile and the following changes: prefix -> PREFIX,
+  BINDIR -> DESTDIR, -O4 -> -O3, mode 644 for man page installation
+  (Michal Vasilek)
+- Make patterns ending in '/' match directories (but not files) for -I / -P
+  (Michiel Beijen) should also fix issues with --gitignore as well
+  (Taylor Faubion)
+- Fix --gitignore not matching files relative to the path of the .gitignore
+  (Taylor Faubion) I did say it was hacked together.
+- Refactored color.c a bit to simplify the code as a prelude to meta coloring.
 
 Version 2.0.0 (12/21/2021)
-  - This started out as a 1.9.0 release but then I got fed up with the
-    abundance of directory listers (8 in total, 2 each for each output mode).
-    Nothing is terribly well tested since there are a lot of changes and I would
-    like to get this out the door finally, please report breakage.  This reduced
-    so much code that all the below additions only resulted in a code base that
-    is only 54 lines larger than 1.8.0.
-  - Rolled all the directory listers into 2 functions that call output specific
-    functions (removes one TODO).
-  - -R option now recursively calls the emit_tree() function rather than using
-    system() to re-call tree.  Also removes a TODO.
-  - Adds --info to print information about files/directories from information
-    found in .info files (removes a maybe do) In HTML output, comments show as
-    mouse over tooltips, which I imagine will be the most useful use of this
-    "feature".
-  - Output un-indented JSON on file descriptor 3 ("stddata") automatically if
-    file descriptor 3 is present (currently Linux only.) Maybe switch to BSON.
-  - Always HTML escape filenames in HTML output even when -C is used.
-    (Eric Pruitt)
-  - Return a non-zero exit status if there is a failure to open any directory.
-  - Added --gitignore option to filter out files specified by .gitignore files.
-    (also reads $GIT_DIR/info/exclude if present.) To facilitate gitignore,
-    adds support for ** on pattern matching to allow /**/ to match a single /.
-    This is not well tested and kind of hacked together, so may not work
-    correctly. (Jake Zimmerman and others)
-  - Now also supports multiple -I and -P instances. (Michiel Beijen and others)
-  - Now prints meta data for the top level directory as well.
-  - Split spaghetti code in main into individual functions.
-  - Properly sort --fromfile input (Chentao Credungtao via Debian)
-  - Make tree colorization use reset (rs code in dir_colors,) not normal color
-    when resetting attributes (Filips Romāns via Debian).
-  - Honor -n (no color) even if the CLICOLOR_FORCE environment variable is set
-    (Paul Seyfert)
-  - Added --metafirst to print the metadata before the indentation lines
-    (suggested by Richard Mitchell)
-  - Fix --sort option to not require =
-  - Defer sorting for --du until the entire sub-directory tree has been
-    processed.
-  - Optimized makefile, HP/UX support (Osipov, Michael). Note that this changes
-    the prefix default to /usr/local, which is becoming required for many
-    systems now.
-  - Renamed (the by now very obsolete) doc/tree.1.fr to doc/tree.fr.1 (Jonas
-    Stein)
-  - Fix JSON string escaping such that it is not using the HTML escaping (Fox
-    & others)
-  - Add --filesfirst option (John A. Fedoruk). Cleaned up sorting code to make
-    --dirsfirst and --filesfirst top level meta-sorts.
-  - "arial" not "ariel" (Mark), HTML style-sheet cleaned up in any event.
-  - Deprecate using local -DLINUX / -DCYGWIN and use the OS provided
-    __linux__ or __CYGWIN__ (Jonas Stein)
-  - XML/HTML/JSON output needs to be mutually exclusive, last command line
-    switch wins. (Sergei Maximov)
-  - Make sure we use xmalloc instead of malloc in a number of places (Tomáš
-    Beránek)
+
+- This started out as a 1.9.0 release but then I got fed up with the
+  abundance of directory listers (8 in total, 2 each for each output mode).
+  Nothing is terribly well tested since there are a lot of changes and I would
+  like to get this out the door finally, please report breakage. This reduced
+  so much code that all the below additions only resulted in a code base that
+  is only 54 lines larger than 1.8.0.
+- Rolled all the directory listers into 2 functions that call output specific
+  functions (removes one TODO).
+- -R option now recursively calls the emit_tree() function rather than using
+  system() to re-call tree. Also removes a TODO.
+- Adds --info to print information about files/directories from information
+  found in .info files (removes a maybe do) In HTML output, comments show as
+  mouse over tooltips, which I imagine will be the most useful use of this
+  "feature".
+- Output un-indented JSON on file descriptor 3 ("stddata") automatically if
+  file descriptor 3 is present (currently Linux only.) Maybe switch to BSON.
+- Always HTML escape filenames in HTML output even when -C is used.
+  (Eric Pruitt)
+- Return a non-zero exit status if there is a failure to open any directory.
+- Added --gitignore option to filter out files specified by .gitignore files.
+  (also reads $GIT_DIR/info/exclude if present.) To facilitate gitignore,
+  adds support for ** on pattern matching to allow /**/ to match a single /.
+  This is not well tested and kind of hacked together, so may not work
+  correctly. (Jake Zimmerman and others)
+- Now also supports multiple -I and -P instances. (Michiel Beijen and others)
+- Now prints meta data for the top level directory as well.
+- Split spaghetti code in main into individual functions.
+- Properly sort --fromfile input (Chentao Credungtao via Debian)
+- Make tree colorization use reset (rs code in dir_colors,) not normal color
+  when resetting attributes (Filips Romāns via Debian).
+- Honor -n (no color) even if the CLICOLOR_FORCE environment variable is set
+  (Paul Seyfert)
+- Added --metafirst to print the metadata before the indentation lines
+  (suggested by Richard Mitchell)
+- Fix --sort option to not require =
+- Defer sorting for --du until the entire sub-directory tree has been
+  processed.
+- Optimized makefile, HP/UX support (Osipov, Michael). Note that this changes
+  the prefix default to /usr/local, which is becoming required for many
+  systems now.
+- Renamed (the by now very obsolete) doc/tree.1.fr to doc/tree.fr.1 (Jonas
+  Stein)
+- Fix JSON string escaping such that it is not using the HTML escaping (Fox
+  & others)
+- Add --filesfirst option (John A. Fedoruk). Cleaned up sorting code to make
+  --dirsfirst and --filesfirst top level meta-sorts.
+- "arial" not "ariel" (Mark), HTML style-sheet cleaned up in any event.
+- Deprecate using local -DLINUX / -DCYGWIN and use the OS provided
+  **linux** or **CYGWIN** (Jonas Stein)
+- XML/HTML/JSON output needs to be mutually exclusive, last command line
+  switch wins. (Sergei Maximov)
+- Make sure we use xmalloc instead of malloc in a number of places (Tomáš
+  Beránek)
 
 Version 1.8.0 (11/16/2018)
-  - Added an experimental --fromfile option (suggested by several people.)
-    This may eventually be replaced or supplimented by a --fromjson option.
-  - Added support for BSD's CLICOLOR and CLICOLOR_FORCE environment variables.
-    (Suggested by Alyssa Ross)
-  - Use strftime() exclusively when formatting date/time to respect locale.
-  - Some man page fixes and cleanups curtsey of Kirill Kolyshkin
-  - Update BINDIR in Makefile for MacOS X -- It is not allowed to install
-    programs to /usr/bin on MacOS X any longer due to System Integrity
-    Protection (SIP) (Shawn Mehan)
-  - Misc patches from Jacob Wahlgren:
-    - Improved command line switch error reporting.
-    - Symbolic links not displayed if a -P pattern is active
-    - Missing argument error reporting fixes on long format switches.
-  - Fixed JSON output hanging commas (John Lane, Tad, others)
-  - JSON size output ignored -h/--si flags (Wagner Camarao)
-  - Fixed issue with malformed multibyte string handling. (Mantas
-    Mikul&#279;nas)
-  - Fixed issue where mbstowcs() fails to null terminate the string due to
-    improper UTF-8 encoding leading to garbage being printed. (Nick Craig-Wood)
-  - Found a bug where the wrong inode (and device) information would be printed
-    for symbolic links. (Stephan Gabert)
+
+- Added an experimental --fromfile option (suggested by several people.)
+  This may eventually be replaced or supplimented by a --fromjson option.
+- Added support for BSD's CLICOLOR and CLICOLOR_FORCE environment variables.
+  (Suggested by Alyssa Ross)
+- Use strftime() exclusively when formatting date/time to respect locale.
+- Some man page fixes and cleanups curtsey of Kirill Kolyshkin
+- Update BINDIR in Makefile for MacOS X -- It is not allowed to install
+  programs to /usr/bin on MacOS X any longer due to System Integrity
+  Protection (SIP) (Shawn Mehan)
+- Misc patches from Jacob Wahlgren:
+  - Improved command line switch error reporting.
+  - Symbolic links not displayed if a -P pattern is active
+  - Missing argument error reporting fixes on long format switches.
+- Fixed JSON output hanging commas (John Lane, Tad, others)
+- JSON size output ignored -h/--si flags (Wagner Camarao)
+- Fixed issue with malformed multibyte string handling. (Mantas
+  Mikul&#279;nas)
+- Fixed issue where mbstowcs() fails to null terminate the string due to
+  improper UTF-8 encoding leading to garbage being printed. (Nick Craig-Wood)
+- Found a bug where the wrong inode (and device) information would be printed
+  for symbolic links. (Stephan Gabert)
 
 Version 1.7.0 (04/23/2014)
-  - Allow user/group names up to 32 characters before clipping.
-  - Made -i compress XML and JSON output as much as possible by eliminating
-    extraneous whitespace.
-  - Added --caseinsensitive (renamed --ignore-case ala grep) flag so patterns
-    match without regard to case, courtesy of Jason A Donenfeld.
-  - Added --matchdirs option courtesy of Brian Mattern & Jason A. Donenfeld
-    <Jason@zx2c4.com>.
-  - Fixed possible buffer overflow on large uid/gids w/o user names/group
-    names (Alexandre Wendling <alexandrerw@celepar.pr.gov.br>)
-  - Added JSON support courtesy of Florian Sesser <fs@it-agenten.com>.
-  - Fixed formatting error with HTML output when -L 1 specified. (Sascha Zorn 
-    <sascha.zorn@gmail.com>)
-  - Added file size sorting (Philipp M?ller <philippausmuensing@googlemail.com>)
-  - Added '--sort[=]<name>' option, ala ls.
-  - Fixed OS X makefile problems (Ryan Hollis <theryanhollis@gmail.com>)
-  - Fixed possible memory overflow in read_dir (path/lbuf not equal in size
-    to pathsize/lbufsize.) (Han Hui <hanhui03@163.com>)
-  - Fix S_ISDOOR/S_IFDOOR spelling mistake for Solaris. (Tim Mooney
-    <Tim.Mooney@ndsu.edu>)
-  - Make tree more reliably detect UTF-8 locales. (Mantas Mikulnas
-    <grawity@gmail.com> and others.)
-  - Return non-zero exit status on option errors, print usage to stdout when
-    not an error, add the posix '--' option terminator, Change -S description
-    to mean CP437 (console) output codes, not ASCII. (Ivan Shmakov
-    <oneingray@gmail.com>)
+
+- Allow user/group names up to 32 characters before clipping.
+- Made -i compress XML and JSON output as much as possible by eliminating
+  extraneous whitespace.
+- Added --caseinsensitive (renamed --ignore-case ala grep) flag so patterns
+  match without regard to case, courtesy of Jason A Donenfeld.
+- Added --matchdirs option courtesy of Brian Mattern & Jason A. Donenfeld
+  <Jason@zx2c4.com>.
+- Fixed possible buffer overflow on large uid/gids w/o user names/group
+  names (Alexandre Wendling <alexandrerw@celepar.pr.gov.br>)
+- Added JSON support courtesy of Florian Sesser <fs@it-agenten.com>.
+- Fixed formatting error with HTML output when -L 1 specified. (Sascha Zorn
+  <sascha.zorn@gmail.com>)
+- Added file size sorting (Philipp M?ller <philippausmuensing@googlemail.com>)
+- Added '--sort[=]<name>' option, ala ls.
+- Fixed OS X makefile problems (Ryan Hollis <theryanhollis@gmail.com>)
+- Fixed possible memory overflow in read_dir (path/lbuf not equal in size
+  to pathsize/lbufsize.) (Han Hui <hanhui03@163.com>)
+- Fix S_ISDOOR/S_IFDOOR spelling mistake for Solaris. (Tim Mooney
+  <Tim.Mooney@ndsu.edu>)
+- Make tree more reliably detect UTF-8 locales. (Mantas Mikulnas
+  <grawity@gmail.com> and others.)
+- Return non-zero exit status on option errors, print usage to stdout when
+  not an error, add the posix '--' option terminator, Change -S description
+  to mean CP437 (console) output codes, not ASCII. (Ivan Shmakov
+  <oneingray@gmail.com>)
 
 Version 1.6.0 (05/24/11)
-  - Re-org of code into multiple files, split HTML and Unix listdir() into
-    separate functions, various code cleanups and optimizations.
-  - Fixed a memory leak in listdir() when memory was allocated early and not
-    freed before function exit.
-  - Fixed possible buffer overflow where symbolic links are followed.
-  - Fixed links printing "argetm" before the name of the link when the LINK
-    setting for DIR_COLORS is set to target (Markus Schnalke
-    <meillo@marmaro.de>)
-  - More fully support dir colors -- added support for su, sg, tw, ow, & st
-    options (and "do" in theory).
-  - Use the environment variable "TREE_COLORS" instead of "LS_COLORS" for
-    color information if it exists.
-  - Added --si flag to print filesizes in SI (powers of 1000) units (Ulrich
-    Eckhardt)
-  - Added -Q to quote filenames in double quotes.  Does not override -N or -q.
-  - Control characters are no longer printed in carrot notation, but as
-    backslashed octal, ala ls, except for codes 7-13 which are printed as
-    \a, \b, \t, \n, \v, \f and \r respectively. Spaces and backslashes are
-    also now backslashed as per ls, for better input to scripts unless -Q
-    is in use (where "'s are backslashed.) (Ujjwal Kumar)
-  - Added -U for unsorted listings (directory order).
-  - Added -c for sorting by last status change (ala ls -c).
-  - --dirsfirst is now a meta-sort and does not override -c, -v, -r or -t, but
-    is disabled by -U.
-  - After many requests, added the ability to process the entire tree before
-    emitting output.  Used for the new options --du, which works like the du
-    command: sums the amount of space under each directory and prints a total
-    amount used in the report and the --prune option which will prune all empty
-    directories from the output (makes the -P option output much more readable.)
-    It should be noted that this will be slow to output when processing large
-    directory trees and can consume copious amounts of memory, use at your own
-    peril.
-  - Added -X option to emit the directory tree in XML format (turns colorization
-    off always.)
-  - Added --timefmt option to specify the format of time display (implies -D).
-    Uses the strftime format.
+
+- Re-org of code into multiple files, split HTML and Unix listdir() into
+  separate functions, various code cleanups and optimizations.
+- Fixed a memory leak in listdir() when memory was allocated early and not
+  freed before function exit.
+- Fixed possible buffer overflow where symbolic links are followed.
+- Fixed links printing "argetm" before the name of the link when the LINK
+  setting for DIR_COLORS is set to target (Markus Schnalke
+  <meillo@marmaro.de>)
+- More fully support dir colors -- added support for su, sg, tw, ow, & st
+  options (and "do" in theory).
+- Use the environment variable "TREE_COLORS" instead of "LS_COLORS" for
+  color information if it exists.
+- Added --si flag to print filesizes in SI (powers of 1000) units (Ulrich
+  Eckhardt)
+- Added -Q to quote filenames in double quotes. Does not override -N or -q.
+- Control characters are no longer printed in carrot notation, but as
+  backslashed octal, ala ls, except for codes 7-13 which are printed as
+  \a, \b, \t, \n, \v, \f and \r respectively. Spaces and backslashes are
+  also now backslashed as per ls, for better input to scripts unless -Q
+  is in use (where "'s are backslashed.) (Ujjwal Kumar)
+- Added -U for unsorted listings (directory order).
+- Added -c for sorting by last status change (ala ls -c).
+- --dirsfirst is now a meta-sort and does not override -c, -v, -r or -t, but
+  is disabled by -U.
+- After many requests, added the ability to process the entire tree before
+  emitting output. Used for the new options --du, which works like the du
+  command: sums the amount of space under each directory and prints a total
+  amount used in the report and the --prune option which will prune all empty
+  directories from the output (makes the -P option output much more readable.)
+  It should be noted that this will be slow to output when processing large
+  directory trees and can consume copious amounts of memory, use at your own
+  peril.
+- Added -X option to emit the directory tree in XML format (turns colorization
+  off always.)
+- Added --timefmt option to specify the format of time display (implies -D).
+  Uses the strftime format.
 
 Version 1.5.3 (11/24/09)
-  - Properly quote directories for the system command when tree is relaunched
-    using the -R option.
-  - Fixed possible indentation problem if dirs[*] is not properly zeroed
-    (Martin Nagy).
-  - Use strcoll() instead of strcmp() to sort files based on locale if set.
-  - Change "const static" to "static const" to remove some compiler warnings
-    for Solaris (Kamaraju Kusumanchi).
-  - Actually use TREE_CHARSET if it's defined.
-  - Automatically select UTF-8 charset if TREE_CHARSET is not set, and the
-    locale is set to *UTF-8 (overridden with --charset option.)
+
+- Properly quote directories for the system command when tree is relaunched
+  using the -R option.
+- Fixed possible indentation problem if dirs[*] is not properly zeroed
+  (Martin Nagy).
+- Use strcoll() instead of strcmp() to sort files based on locale if set.
+- Change "const static" to "static const" to remove some compiler warnings
+  for Solaris (Kamaraju Kusumanchi).
+- Actually use TREE_CHARSET if it's defined.
+- Automatically select UTF-8 charset if TREE_CHARSET is not set, and the
+  locale is set to \*UTF-8 (overridden with --charset option.)
 
 Version 1.5.2.2 (01/22/09)
-  - Set locale before checking MB_CUR_MAX.
-  - Added HP-NonStop platform support (Craig McDaniel <craigmcd@gmail.com>)
-  - Fixed to support 32 bit UID/GIDs.
-  - Added Solaris build options to Makefile (edit and uncomment to use).
-    Provided by Wang Quanhong
+
+- Set locale before checking MB_CUR_MAX.
+- Added HP-NonStop platform support (Craig McDaniel <craigmcd@gmail.com>)
+- Fixed to support 32 bit UID/GIDs.
+- Added Solaris build options to Makefile (edit and uncomment to use).
+  Provided by Wang Quanhong
 
 Version 1.5.2.1 (08/29/08)
-  - Added strverscmp.c file for os's without strverscmp.  Source file is
-    attributed to: Jean-Franois Bignolles <bignolle@ecoledoc.ibp.fr>
-  - Try different approach to MB_CUR_MAX problem.
-  - Changed the argument to printit() to be signed char to avoid warnings.
+
+- Added strverscmp.c file for os's without strverscmp. Source file is
+  attributed to: Jean-Franois Bignolles <bignolle@ecoledoc.ibp.fr>
+- Try different approach to MB_CUR_MAX problem.
+- Changed the argument to printit() to be signed char to avoid warnings.
 
 Version 1.5.2 (06/06/08)
-  - Added --filelimit X option to not descend directories that have more than
-    X number of files in them.
-  - Added -v option for version sorting (also called natural sorting) ala ls.
+
+- Added --filelimit X option to not descend directories that have more than
+  X number of files in them.
+- Added -v option for version sorting (also called natural sorting) ala ls.
 
 Version 1.5.1.2 (06/04/08)
-  - Fixed compile issues related to MB_CUR_MAX on non-linux machines.
-  - Removed unecessary features.h
+
+- Fixed compile issues related to MB_CUR_MAX on non-linux machines.
+- Removed unecessary features.h
 
 Version 1.5.1.1 (06/11/07)
-  - Regression in HTML output, fixed formatting issues.
+
+- Regression in HTML output, fixed formatting issues.
 
 Version 1.5.1 (?)
-  - Remove extraneous / at end of user input directory names when using -f
-    option (Zurd)
-  - List available charsets if --charset option is missing charset argument.
-  - Fixed --charset option processing bug.
-  - Fixed missing <br>'s when -i option used with -H.
-  - Added -h option for human readable output.
-  - Colorization bugfix for special files and directories (make tree behave as
-    ls does)
+
+- Remove extraneous / at end of user input directory names when using -f
+  option (Zurd)
+- List available charsets if --charset option is missing charset argument.
+- Fixed --charset option processing bug.
+- Fixed missing <br>'s when -i option used with -H.
+- Added -h option for human readable output.
+- Colorization bugfix for special files and directories (make tree behave as
+  ls does)
 
 Version 1.5.0 (08/15/04)
-  - Added -T option to change title and H1 header in HTML output.
-  - Added -r option to reverse alpha sort output, ala. 'ls -r'.
-  - '|' wildcard support added by David MacMahon <davidm@astron.Berkeley.EDU>.
-  - Remove extraneous '/' at the end of dirs and dir-symlinks in HTML output.
-  - Removed several possible overflow problems by dynamically allocating
-    arrays in several places.
-  - Better support for Locales and printing utf-8 encoded characters in
-    filenames (still hackish).
-  - Fixed -t to alphasort files with same time-stamps.
-  - Fixed encoding of filenames in HTML output, Kyosuke and others.
-  - Patches by Kyosuke Tokoro <NBG01720@nifty.ne.jp>:
-    - Now, runs OS/2 systems.
-      + Print the file attributes in 'adhrs' format for each file, instead
-        of the protections in 'drwxrwxrwx' format, when running the tree
-        on OS/2 with option -p.
-    - Added --charset option, to specify which character set is used for
-      output.
-       + You can specify any IANA registered character set name. But I have
-         tested only following character sets:
-               Shift_JIS       EUC-JP          IBM850
-               UTF-8           ISO-8859-1      US-ASCII
-       + Now, `-S' option is equal to `--charset=IBM437'.
-       + When running on OS/2 systems, the default value of this option
-         is according to current codepage.  On the other systems, no default.
-  - Change font-weight to font-size in CSS .VERSION.
-  - Change version to standard major.minor.patch format.
-  - Switch from artistic license to GPLv2.
+
+- Added -T option to change title and H1 header in HTML output.
+- Added -r option to reverse alpha sort output, ala. 'ls -r'.
+- '|' wildcard support added by David MacMahon <davidm@astron.Berkeley.EDU>.
+- Remove extraneous '/' at the end of dirs and dir-symlinks in HTML output.
+- Removed several possible overflow problems by dynamically allocating
+  arrays in several places.
+- Better support for Locales and printing utf-8 encoded characters in
+  filenames (still hackish).
+- Fixed -t to alphasort files with same time-stamps.
+- Fixed encoding of filenames in HTML output, Kyosuke and others.
+- Patches by Kyosuke Tokoro <NBG01720@nifty.ne.jp>:
+  - Now, runs OS/2 systems.
+    - Print the file attributes in 'adhrs' format for each file, instead
+      of the protections in 'drwxrwxrwx' format, when running the tree
+      on OS/2 with option -p.
+  - Added --charset option, to specify which character set is used for
+    output.
+    - You can specify any IANA registered character set name. But I have
+      tested only following character sets:
+      Shift_JIS EUC-JP IBM850
+      UTF-8 ISO-8859-1 US-ASCII
+    - Now, `-S' option is equal to `--charset=IBM437'.
+    - When running on OS/2 systems, the default value of this option
+      is according to current codepage. On the other systems, no default.
+- Change font-weight to font-size in CSS .VERSION.
+- Change version to standard major.minor.patch format.
+- Switch from artistic license to GPLv2.
 
 Version 1.4 (02/21/02 (b1), 03/24/02 (b2), 02/06/03 (b3))
-  - Added large file support under Linux.
-  - Fixed crashing on missing command line arguments.
-  - Fixed several memory leaks
-  - Added --dirsfirst option to list directories first.
-  - Fixed formatting error when unable to open directories.
-  - Fixed bug in parse_dir_colors().
-  - Changed -I to also ignore directories.
-  - Added --nolinks command to turn off hyperlinks with the HTML output.
-  - Fixed several memory leaks in listdir().
-  - Some additional code cleanup in listdir().
-  - Some systems may define TRUE/FALSE, so don't create the enums for TRUE
-    and FALSE if that's the case.
-  - Fixed over-allocation bug in read_dir().
-  - Added crude beginnings of color output for HTML via CSS (Ted Tiberio
-    ttiberio@rochester.rr.com).
-  - Fixed buffer overflow problem in dircolors parsing.
-  - Fixed recursive symlink detection.
-  - Added --inodes and --device options.
-  - Added --noreport option.
+
+- Added large file support under Linux.
+- Fixed crashing on missing command line arguments.
+- Fixed several memory leaks
+- Added --dirsfirst option to list directories first.
+- Fixed formatting error when unable to open directories.
+- Fixed bug in parse_dir_colors().
+- Changed -I to also ignore directories.
+- Added --nolinks command to turn off hyperlinks with the HTML output.
+- Fixed several memory leaks in listdir().
+- Some additional code cleanup in listdir().
+- Some systems may define TRUE/FALSE, so don't create the enums for TRUE
+  and FALSE if that's the case.
+- Fixed over-allocation bug in read_dir().
+- Added crude beginnings of color output for HTML via CSS (Ted Tiberio
+  ttiberio@rochester.rr.com).
+- Fixed buffer overflow problem in dircolors parsing.
+- Fixed recursive symlink detection.
+- Added --inodes and --device options.
+- Added --noreport option.
 
 Version 1.3 (02/15/99)
-  - Fixed long pathname problem by dynamically allocating the path.
-  - Added recursive symlink detection.
-  - Added --help and --version options.
-  - When -C is used and LS_COLORS is undefined, tree uses a default color
-    scheme (thus -C always forces color output now).
-  - Added -S to show ASCII tree lines (Gerald Scheidl)
-  - Made tree more portable (Guido Socher and others)
 
-  Following options courtesy of Francesc Rocher:
-  - Added -o <filename> to redirect the output.
-  - Added -H <baseHRef> to print the tree in HTML format.
-  - Added -L to set the maximum level of directories to print.
-  - Added -R to recursively restart the search at the level given by `-L'
-    option (adding as well `-o 00Tree.html').
+- Fixed long pathname problem by dynamically allocating the path.
+- Added recursive symlink detection.
+- Added --help and --version options.
+- When -C is used and LS_COLORS is undefined, tree uses a default color
+  scheme (thus -C always forces color output now).
+- Added -S to show ASCII tree lines (Gerald Scheidl)
+- Made tree more portable (Guido Socher and others)
+
+Following options courtesy of Francesc Rocher:
+
+- Added -o <filename> to redirect the output.
+- Added -H <baseHRef> to print the tree in HTML format.
+- Added -L to set the maximum level of directories to print.
+- Added -R to recursively restart the search at the level given by `-L'
+option (adding as well `-o 00Tree.html').
 
 Version 1.2 (01/05/97)
-  - Added -D to print the date of the last modification.
-  - Added -t option to sort by last modification time (ala ls -t).
-  - Added -I <pattern>, similar to the -P option except tree does not print
-    those files which match the pattern.
-  - Made tree print non-printable characters in filenames in standard unix
-    carrot notation.
-  - Added -N option to make tree print filenames without any processing.
-  - Added -q option to make tree print non-printable characters in filenames
-    as question marks.
-  - Added `|' to -F output and made it only print character type after the
-    link on sym-links, not on the symlink name itself.
-  - Added -u option to display username/uid, and -g option to display group
-    name/gid.
-  - Fully (pass the salt) implemented dircolors support.
+
+- Added -D to print the date of the last modification.
+- Added -t option to sort by last modification time (ala ls -t).
+- Added -I <pattern>, similar to the -P option except tree does not print
+  those files which match the pattern.
+- Made tree print non-printable characters in filenames in standard unix
+  carrot notation.
+- Added -N option to make tree print filenames without any processing.
+- Added -q option to make tree print non-printable characters in filenames
+  as question marks.
+- Added `|' to -F output and made it only print character type after the
+  link on sym-links, not on the symlink name itself.
+- Added -u option to display username/uid, and -g option to display group
+  name/gid.
+- Fully (pass the salt) implemented dircolors support.
 
 Version 1.1 (07/09/96)
-  - Made some changes to the Makefile to insure proper installation and for
-    multi-architecture support and a bug-fix.
-  - Made root directory colorized if dircolors is enabled.
-  - Put []'s around permission and size info, 'cause I think it looks better.
-  - Added -A option to enable ANSI-lines hack.
-  - Added some sanity checks for dircolors support.
-  - Added -P <pattern> to list only those files that match the wildcard
-    given in <pattern>.
-  - Fixed error where relative symbolic links to directories would not be
-    followed when the -l option was used.
-  - Made uid 0 the same as anyone else (-a was default for uid 0)
-  - Added -x directive to stay on one filesystem (ala find -xdev).
+
+- Made some changes to the Makefile to insure proper installation and for
+  multi-architecture support and a bug-fix.
+- Made root directory colorized if dircolors is enabled.
+- Put []'s around permission and size info, 'cause I think it looks better.
+- Added -A option to enable ANSI-lines hack.
+- Added some sanity checks for dircolors support.
+- Added -P <pattern> to list only those files that match the wildcard
+  given in <pattern>.
+- Fixed error where relative symbolic links to directories would not be
+  followed when the -l option was used.
+- Made uid 0 the same as anyone else (-a was default for uid 0)
+- Added -x directive to stay on one filesystem (ala find -xdev).
 
 Version 1.0 (??/??/90?)
-  - The original, a model of perfection...
+
+- The original, a model of perfection...

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ PREFIX=/usr/local
 CC ?= gcc
 INSTALL ?= install
 
-VERSION=2.2.1
+VERSION=2.3.0
 TREE_DEST=tree
 DESTDIR=${PREFIX}/bin
 MAN=tree.1
 # Probably needs to be ${PREFIX}/share/man for most systems now
 MANDIR=${PREFIX}/man
-OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o
+OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o markdown.o
 
 # Uncomment options below for your particular OS:
 

--- a/README
+++ b/README
@@ -39,6 +39,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
   - Display file permissions, owner, group, size, inode, device ID, and modification/status change times.
   - Human-readable file sizes (including SI units).
   - Compute directory sizes based on their contents.
+  - Word count for files (directory word count is 0).
 - **Sorting:**
   - Sort by name, version, size, modification time, or status change time.
   - Reverse sort order.
@@ -59,6 +60,28 @@ make
 ```
 
 This will usually compile the source files and produce an executable named `tree`. You can then move this executable to a directory in your system's `PATH` (e.g., `/usr/local/bin`).
+
+### Local Installation
+
+To install `tree` locally (e.g., in `~/.local/bin`), you can use the `PREFIX` variable during the build and installation process:
+
+```sh
+make PREFIX=$HOME/.local
+make install PREFIX=$HOME/.local
+```
+
+This will install the `tree` executable to `$HOME/.local/bin/tree` and its man page to `$HOME/.local/share/man/man1/tree.1` or `$HOME/.local/man/man1/tree.1`. Ensure that `$HOME/.local/bin` is in your system's `PATH` to run `tree` directly.
+
+### Uninstallation
+
+To uninstall `tree` if you installed it locally using the `PREFIX` method:
+
+```sh
+rm -f $HOME/.local/bin/tree
+rm -f $HOME/.local/share/man/man1/tree.1
+rm -f $HOME/.local/man/man1/tree.1 # On some systems
+make clean # To remove compiled files from the source directory
+```
 
 ## Usage
 
@@ -108,7 +131,7 @@ Below is a comprehensive list of command-line options available for `tree`:
 - `-h` Print the size in a more human readable way.
 - `--si` Like `-h`, but use in SI units (powers of 1000).
 - `--du` Compute size of directories by their contents.
-- `-w` Print the word count for files and directories. (Note: This option appeared in your help output but might not be a standard `tree` option or might be specific to your version.)
+- `-w` Print the word count for files. For directories, the word count is 0. For files, it attempts to process text files and heuristically skips binary files.
 - `-D` Print the date of last modification or (`-c`) status change.
 - `--timefmt fmt` Print and format time according to the format `fmt`.
 - `-F` Appends `/`, `=`, `*`, `@`, `|` or `>` as per `ls -F`.
@@ -138,7 +161,7 @@ Below is a comprehensive list of command-line options available for `tree`:
 
 - `-X` Prints out an XML representation of the tree.
 - `-J` Prints out an JSON representation of the tree.
-- `-M` Prints out a Markdown bullet list representation of the tree. (Note: This option appeared in your help output but might not be a standard `tree` option or might be specific to your version.)
+- `-M` Prints out a Markdown bullet list representation of the tree.
 - `-H baseHREF` Prints out HTML format with `baseHREF` as top directory.
   - If `baseHREF` is `-`, the HTML output will use relative paths.
 - `-T string` Replace the default HTML title and H1 header with `string`.

--- a/README
+++ b/README
@@ -1,367 +1,212 @@
-  Please read the INSTALL file for installation instructions, particularly if
-you are installing on a non-Linux machine.
-
-  This is a handy little utility to display a tree view of directories that
-I wrote some time ago and just added color support to.  I've decided that
-since no one else has done something similar I would go ahead and release
-it, even though it's barely a 1st year CS student hack.  I've found it damn
-handy to peruse a directory tree though, especially when someone is trying to
-hide something from you.
-
-  The main distribution site for tree is here:
-  http://oldmanprogrammer.net/source.php?dir=projects/tree
-
-  Backup GIT sites are:
-  https://gitlab.com/OldManProgrammer/unix-tree
-  https://github.com/Old-Man-Programmer/tree
-
-  Current e-mail address to reach me at: steve.baker.llc@gmail.com
-
-  If you don't like the way it looks let me know how you think it should be
-formatted. Feel free to suggest modifications and additions.
-
-  Thanks go out so the following people who have helped bring tree to the
-pinnacle of perfection that it is: ;)
-
-Francesc Rocher
-  - Added HTML output (-H).
-  - Added options -o, -L and -R.
-
-Gerald Scheidl
-  - Added -S option to print ASCII graphics lines for use under linux
-    console when an alternate console font has been selected (might also
-    work under DOS telnet).
-
-Guido Socher (and others)
-  - Made tree more portable.  Should compile under solaris.
-
-Mitja Lacen
-  - Discovered bug where tree will segmentation fault on long pathnames.
-  - Discovered in -L argument processing.
-
-Nathaniel Delage
-  - Discovered problem with recursive symlink detection
-
-A. Karthik
-  - Suggested option to remove file and directory report at end of tree
-    listing.
-
-Roger Luethi
-  - Spotted memory over-allocation bug in read_dir().
-  - Submitted several patches to fix various memory leaks.
-
-Daniel Lee
-  - Reported that Tru64 defines TRUE/FALSE in sys/types.h (OSF1 standard?)
-
-Paolo Violini
-  - Found bug in tree that caused it to seg-fault if 50 file arguments where
-    given and directory coloring was turned on.
-
-Mitsuaki Masuhara
-  - Discovered tree crashed on missing arguments.
-  - Discovered that tree did not properly encode characters in filenames
-    when used as URLs when using the -H option.
-  - Fixed issue with --charset option processing.
-
-Johan Fredrik
-  - Pointed out that tree did not list large files.
-
-Ted Tiberio
-  - Submitted patch which fixed a compiler issue and cleaned up HTML and CSS
-    code, applied CSS to all output, and fixed up HTML to 4.01 strict
-    standards.
-
-David MacMahon
-  - Added '|' support to the pattern matching routines.
-
-Dan Jacobson
-  - Pointed out that -t did not sort properly for files with the same
-    timestamp.
-  - Suggested option to change HTML title and H1 string.
-  - Suggested -r option for reversed alphanumeric sort ala 'ls -r'.
-
-Kyosuke Tokoro
-  - Provided patch to support OS/2, fix HTML encoding, provide charset
-    support. Added to authors list.
-
-Florian Ernst
-  - Debian maintainer who pointed out problems and applied fire to feet to fix
-    stuff.
-
-Jack Cuyler
-  - Suggested -h option for human readable output for -s, ala ls -lh.
-
-Jonathon Cranford
-  - Supplied patch to make tree under cygwin.
-
-Richard Houser
-  - Provided patch to fix a colorization bug when dealing with special
-    files and directories that seem to have an extension.
-
-Zurd (?)
-  - Suggested removing trailing slash on user supplied directory names if -f
-    option is used.
-
-John Nintendud
-  - Pointed out broken HTML output in 1.5.1.
-
-Mark Braker
-  - Suggested --filelimit option.
-
-Michael Vogt
-  - Suggested -v option (version sort).
-
-Wang Quanhong
-  - Provided build options for Solaris.
-
-Craig McDaniel
-  - Provided build options and source mods for HP NonStop support.
-
-Christian Grigis
-  - Noted that setlocale() should come before MB_CUR_MAX check.
-
-Kamaraju Kusumanchi
-  - Submitted patch to remove compiler warnings for Solaris.
-
-Martin Nagy
-  - Provided patch which fixes issue where indent may output more than it
-    should when dirs[*] is not properly cleared before use.
-
-William C. Lathan III
-  - Showed that tree was not properly quoting arguments to recursively called
-    tree instances when using -R.
-
-Ulrich Eckhardt
-  - Submitted patch for --si option.
-
-Tim Waugh (redhat)
-  - Pointed out a potential memory leak in listdir().
-
-Markus Schnalke
-  - Tracked down bug where tree would print "argetm" before the filename of a
-    symbolic link when the "target" option was specified for LINK in dircolors.
-
-Ujjwal Kumar
-  - Suggested that tree backslash spaces like ls does for script use.  Made
-    output more like ls.
-
-Ivan Shmakov
-  - Pointed out multiple CLI defenciencies (via Debian)
-
-Mantas Mikulnas
-  - Provided patch to make tree more reliably detect the UTF-8 locale.
-
-Tim Mooney
-  - Noticed S_ISDOOR/S_IFDOOR spelling mistake for under Solaris.
-
-Han Hui
-  - Pointed out possible memory overflow in read_dir (path/lbuf not equal in size
-    to pathsize/lbufsize.)
-
-Ryan Hollis
-  - Pointed out problems with the Makefile w/ respect to OSX.
-
-Philipp M?ller
-  - Provided patch for filesize sorting.
-
-Sascha Zorn
-  - Pointed out that the HTML output was broken when -L 1 option was used.
-
-Alexandre Wendling
-  - Pointed out that modern systems may use 32 bit uid/gids which could lead
-    to a potential buffer overflow in the uid/gid to name mapping functions.
-
-Florian Sesser
-  - Provided patch to add JSON support.
-
-Brian Mattern & Jason A. Donenfeld
-  - Provided patch to add --matchdirs functionality.
-
-Jason A. Donenfeld
-  - Added --caseinsentive, renamed --ignore-case option.
-  - Bugged me a lot.
-
-Stephan Gabert
-  - Found a bug where the wrong inode (and device) information would be printed
-    for symbolic links.
-
-Nick Craig-Wood
-  - Fixed issue where mbstowcs() fails to null terminate the string due to
-    improper UTF-8 encoding leading to garbage being printed.
-
-Mantas Mikulėnas
-  - Fixed issue with malformed multibyte string handling.
-
-Wagner Camarao
-  - Pointed out that JSON size output ignored -h/--si flags
-
-John Lane, Tad, others
-  - Fixed JSON output hanging commas
-
-Jacob Wahlgren
-  - Improved command line switch error reporting.
-  - Symbolic links not displayed if a -P pattern is active
-  - Missing argument error reporting fixes on long format switches.
-
-Shawn Mehan
-  - Update BINDIR in Makefile for MacOS X -- It is not allowed to install
-    programs to /usr/bin on MacOS X any longer due to System Integrity
-    Protection (SIP)
-
-Kirill Kolyshkin
-  - Some man page fixes and cleanups
-
-Alyssa Ross
-  - Suggested adding support for BSD's CLICOLOR and CLICOLOR_FORCE environment
-    variables.
-
-Tomáš Beránek
-  - Make sure we always use xmalloc / xrealloc
-
-Sergei Maximov
-  - Make XML/HTML/JSON output mutually exclusive.
-
-Jonas Stein
-  - Deprecate using local -DLINUX / -DCYGWIN and use the OS provided defines
-
-John A. Fedoruk
-  - Suggested --filesfirst option.
-
-Michael Osipov
- - Optimized makefile, HP/UX support.
-
-Richard Mitchell
-  - Suggested --metafirst option
-
-Paul Seyfert
-  - Honor -n (no color) even if the CLICOLOR_FORCE environment variable is set
-
-Filips Romāns via Debian
-  - Make tree colorization use reset (rs code in dir_colors,) not normal color
-    when resetting attributes.
-
-Chentao Credungtao via Debian
-  - Properly sort --fromfile input
-
-Jake Zimmerman (and others)
-  - Suggest support for .gitignore files (--gitignore option)
-
-Eric Pruitt
-  - Always HTML escape filenames in HTML output even when -C is used.
-
-Michiel Beijen (and others)
-  - Suggest Support multiple -I and -P instances.
-  - Suggest that / match directories in patterns (also Taylor Faubion)
-  - Suggested to update MANPATH for OS X
-
-Michal Vasilek
-  - Various Makefile fixes
-
-Josey Smith
-  - Reported an error with * in the patchmatch code where *foo*bar would match
-    *foo alone.
-
-Maxim Cournoyer
- - Reported HTML url output issue w/ 2.0.0-2.0.1
-
-Ben Brown
- - Updates to the Makefile
- - Reported use after free error
-
-Erik Skultety
- - Reported same use after error
-
-Saniya Maheshwari / Mig-hub ? / Carlos Pinto
- - Reported various issues with --gitignore
-
-Piotr Andruszkow
- - Suggested adding support for --info and --gitignore for the --fromfile
-   option.
-
-Sebastian Rose
- - Another attempt at fixing extraneous /'s in HTML URLs/output.
-
-Dave Rice
- - Fixed XML output
-
-Timm Fitschen
- - Suggest adding support for the NO_COLOR environment variable.
-
-Chentao Credungtao
- - Suggested supporting symbolic links in --fromfile (--fflinks option)
-
-Sith Wijesinghe and Matthew Sessions
- - Remove many C90 isms to make compiling with C90 compilers easier.
-
-simonpmind (gitlab)
- - Reported issue where following links while doing JSON output would lead to
-   incorrect JSON output.
- - Suggested suppressing 'recursive, not followed' when using -L, fixing JSON
-   error.
-
-German Lashevich
- - Reported an issue where .info patterns relative to the .info file that did
-   not use a wildcard for matching the prefix were not matching files properly.
-
-Javier Jaramago Fernández
- - Reported a buffer overflow in listdir() when file names are allowed to be
-   longer than 256 characters (like when using fromfile.)
-
-6ramr (gitlab)
- - Reported issue with following symbolic links when a full tree was gathered.
-
-Clinton
- - Reported issue where --gitignore does not think a pattern with a singular
-   terminal '/' (indicating it matches only directories,) is a relative path.
-
-jack6th (gitlab)
- - Don't prematurely sort files/directories with --from*file.
-
-Hanqin Guan (The OSLab of Peking University):
- - Fuzzing testing that identified several problems in --fromfile and
-   --fromtabfile processing.
- - -U should disable --dirsfirst / --filesfirst sorting.
- - Make sure gittrim() function can handle a null string.
-
-Trevor Gross
- - Suggested adding support for immediate values to -L with no spacing.
-
-Christoph Anton Mitterer
- - Suggested option negation, which led to --opt-toggle.
-
-Nicolai Dagestad
- - Suggested --hyperlink option.
-
-Alchemyst (github)
- - Reported JSON error when using the --du option and unable to open a
-   directory.
- - Reported that the reported total was incorrect when using the --du option.
-
-Ivan Ivanovich
- - Reported small rounding error in human readable size output.
-
-Kenta Arai
- - Reported Segfault with --filelimit option
- - Add NULL guard for json_printinfo() and xml_printinfo() (and fix ftype
-   printing for XML)
- - Fix getcharset() to not return a getenv() pointer.
- - Suggest adding .gitignore file to the distribution.
- - Clean up some warnings issued by -Wextra
-
-freemedom (github)
- - Provided Makefile information for cross compiling for Android.
-
-David Seifert
- - Provided updates for Makefile
- - Suggested move to stdbool.h to avoid problems with newer compilers.
-
-Daniel Li / Landon Bourma
- - Reported segfault from incorrect free.
- 
-And many others whom I've failed to keep track of.  I should have started
-this list years ago.
-
-					- Steve Baker
-					  Steve.Baker.llc@gmail.com
-					  or
-					  oldmanprogrammer.llc@gmail.com
+# Tree - Directory Listing Utility
+
+## Overview
+
+`tree` is a recursive directory listing program that produces a depth-indented listing of files. With no arguments, `tree` lists the files in the current directory. When directory arguments are given, `tree` lists all the files and/or directories found in the given directories each in turn. `tree` then returns the total number of files and/or directories listed.
+
+There are options to change the characters used in the output, and to use color output. Graphical options are also provided to change the type of indentation lines. Various other options exist to modify the output, including filtering, sorting, and output formats like XML, JSON, HTML, and Markdown.
+
+## Version
+
+**Version:** v2.2.1 (1996 - 2024)
+
+## Authors
+
+- Steve Baker (steve.baker.llc@gmail.com)
+- Thomas Moore
+- Francesc Rocher (HTML output)
+- Florian Sesser (JSON output)
+- Kyosuke Tokoro (Charsets / OS/2 support)
+
+## License
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+## Features
+
+- **Recursive Directory Listing:** Displays directory contents in a tree-like format.
+- **Flexible Output:**
+  - Supports plain text, XML, JSON, HTML, and Markdown output.
+  - Customizable character sets and indentation graphics.
+  - Colorized output based on file type.
+- **Filtering:**
+  - Include or exclude files based on patterns.
+  - Support for `.gitignore` files.
+  - Limit recursion depth and number of files per directory.
+- **File Information:**
+  - Display file permissions, owner, group, size, inode, device ID, and modification/status change times.
+  - Human-readable file sizes (including SI units).
+  - Compute directory sizes based on their contents.
+- **Sorting:**
+  - Sort by name, version, size, modification time, or status change time.
+  - Reverse sort order.
+  - Option to list directories before or after files.
+- **Symlink Handling:**
+  - Option to follow symbolic links.
+- **Input Options:**
+  - Read paths from files instead of command-line arguments.
+- **Hyperlinks:**
+  - Generate OSC 8 terminal hyperlinks.
+
+## Building from Source
+
+To build `tree` from source, you typically need a C compiler (like GCC) and the `make` utility. Navigate to the source directory and run:
+
+```bash
+make
+```
+
+This will usually compile the source files and produce an executable named `tree`. You can then move this executable to a directory in your system's `PATH` (e.g., `/usr/local/bin`).
+
+## Usage
+
+```bash
+tree [OPTIONS] [directory ...]
+```
+
+If no directory is specified, `tree` will list the contents of the current directory.
+
+## Options
+
+Below is a comprehensive list of command-line options available for `tree`:
+
+### Listing options
+
+- `-a` All files are listed.
+- `-d` List directories only.
+- `-l` Follow symbolic links like directories.
+- `-f` Print the full path prefix for each file.
+- `-x` Stay on current filesystem only.
+- `-L level` Descend only `level` directories deep.
+- `-R` Rerun tree when max dir level reached.
+- `-P pattern` List only those files that match the pattern given.
+- `-I pattern` Do not list files that match the given pattern.
+- `--gitignore` Filter by using `.gitignore` files.
+- `--gitfile X` Explicitly read a gitignore file `X`.
+- `--ignore-case` Ignore case when pattern matching.
+- `--matchdirs` Include directory names in `-P` pattern matching.
+- `--metafirst` Print meta-data at the beginning of each line.
+- `--prune` Prune empty directories from the output.
+- `--info` Print information about files found in `.info` files.
+- `--infofile X` Explicitly read info file `X`.
+- `--noreport` Turn off file/directory count at end of tree listing.
+- `--charset X` Use charset `X` for terminal/HTML and indentation line output.
+- `--filelimit #` Do not descend dirs with more than `#` files in them.
+- `-o filename` Output to file instead of stdout.
+
+### File options
+
+- `-q` Print non-printable characters as `?`.
+- `-N` Print non-printable characters as is.
+- `-Q` Quote filenames with double quotes.
+- `-p` Print the protections for each file.
+- `-u` Displays file owner or UID number.
+- `-g` Displays file group owner or GID number.
+- `-s` Print the size in bytes of each file.
+- `-h` Print the size in a more human readable way.
+- `--si` Like `-h`, but use in SI units (powers of 1000).
+- `--du` Compute size of directories by their contents.
+- `-w` Print the word count for files and directories. (Note: This option appeared in your help output but might not be a standard `tree` option or might be specific to your version.)
+- `-D` Print the date of last modification or (`-c`) status change.
+- `--timefmt fmt` Print and format time according to the format `fmt`.
+- `-F` Appends `/`, `=`, `*`, `@`, `|` or `>` as per `ls -F`.
+- `--inodes` Print inode number of each file.
+- `--device` Print device ID number to which each file belongs.
+
+### Sorting options
+
+- `-v` Sort files alphanumerically by version.
+- `-t` Sort files by last modification time.
+- `-c` Sort files by last status change time.
+- `-U` Leave files unsorted.
+- `-r` Reverse the order of the sort.
+- `--dirsfirst` List directories before files (`-U` disables).
+- `--filesfirst` List files before directories (`-U` disables).
+- `--sort X` Select sort: `name`, `version`, `size`, `mtime`, `ctime`, `none`.
+
+### Graphics options
+
+- `-i` Don't print indentation lines.
+- `-A` Print ANSI lines graphic indentation lines.
+- `-S` Print with CP437 (console) graphics indentation lines.
+- `-n` Turn colorization off always (`-C` overrides).
+- `-C` Turn colorization on always.
+
+### XML/HTML/JSON/Markdown/Hyperlink options
+
+- `-X` Prints out an XML representation of the tree.
+- `-J` Prints out an JSON representation of the tree.
+- `-M` Prints out a Markdown bullet list representation of the tree. (Note: This option appeared in your help output but might not be a standard `tree` option or might be specific to your version.)
+- `-H baseHREF` Prints out HTML format with `baseHREF` as top directory.
+  - If `baseHREF` is `-`, the HTML output will use relative paths.
+- `-T string` Replace the default HTML title and H1 header with `string`.
+- `--nolinks` Turn off hyperlinks in HTML output.
+- `--hintro X` Use file `X` as the HTML intro.
+- `--houtro X` Use file `X` as the HTML outro.
+- `--hyperlink` Turn on OSC 8 terminal hyperlinks.
+- `--scheme X` Set OSC 8 hyperlink scheme, default `file://`.
+- `--authority X` Set OSC 8 hyperlink authority/hostname.
+
+### Input options
+
+- `--fromfile` Reads paths from files (`.`=stdin).
+- `--fromtabfile` Reads trees from tab indented files (`.`=stdin).
+- `--fflinks` Process link information when using `--fromfile`.
+
+### Miscellaneous options
+
+- `--opt-toggle` Enable option toggling (allows re-specifying an option to toggle its boolean value).
+- `--version` Print version and exit.
+- `--help` Print usage and this help message and exit.
+- `--` Options processing terminator. Any arguments following `--` are treated as directory names, even if they start with a dash.
+
+## Examples
+
+1.  **List current directory:**
+
+    ```bash
+    tree
+    ```
+
+2.  **List a specific directory up to 2 levels deep:**
+
+    ```bash
+    tree -L 2 /path/to/directory
+    ```
+
+3.  **List directories only, showing permissions and sizes:**
+
+    ```bash
+    tree -dps /path/to/directory
+    ```
+
+4.  **List all files, including hidden ones, and output to HTML:**
+
+    ```bash
+    tree -a -H . -o tree_report.html /path/to/directory
+    ```
+
+    (This creates `tree_report.html` with `.` as the base HREFs for links.)
+
+5.  **List files matching a pattern, ignoring case, and sort by modification time:**
+
+    ```bash
+    tree -P "*.txt" --ignore-case -t /path/to/directory
+    ```
+
+6.  **Output as JSON:**
+
+    ```bash
+    tree -J -o output.json /path/to/directory
+    ```
+
+7.  **Use gitignore rules for filtering:**
+    ```bash
+    tree --gitignore /path/to/git-repository
+    ```
+
+## Reporting Bugs / Contributing
+
+If you find any bugs or have suggestions for improvements, please refer to the project's repository or contact the maintainers. Contributions are welcome! (You might want to add a link to your project's issue tracker or contribution guidelines here.)

--- a/html.c
+++ b/html.c
@@ -19,6 +19,7 @@
 
 
 extern bool duflag, dflag, hflag, siflag;
+extern bool wcflag; // Word count flag
 extern bool metafirst, noindent, force_color, nolinks, htmloffset;
 
 extern char *hversion;
@@ -69,7 +70,7 @@ void url_encode(FILE *fd, char *s)
   static const char *reserved = "!#$&'()*+,:;=?@[]";
 
   for(;*s;s++) {
-    fprintf(fd, (isprint((u_int)*s) && (strchr(reserved, *s) == NULL))? "%c":"%%%02X", *s);
+    fprintf(fd, (isprint((unsigned char)*s) && (strchr(reserved, *s) == NULL))? "%c":"%%%02X", *s);
   }
 }
 
@@ -247,7 +248,11 @@ void html_report(struct totals tot)
   if (dflag)
     fprintf(outfile,"%ld director%s\n",tot.dirs,(tot.dirs==1? "y":"ies"));
   else
-    fprintf(outfile,"%ld director%s, %ld file%s\n",tot.dirs,(tot.dirs==1? "y":"ies"),tot.files,(tot.files==1? "":"s"));
+	fprintf(outfile,"%ld director%s, %ld file%s",tot.dirs,(tot.dirs==1? "y":"ies"),tot.files,(tot.files==1? "":"s"));
+
+	if (wcflag) {
+	fprintf(outfile, ", %lld total word%s", (long long int)tot.total_word_count, (tot.total_word_count==1?"":"s"));
+	}
 
   fprintf(outfile, "\n</p>\n");
 }

--- a/json.c
+++ b/json.c
@@ -19,6 +19,7 @@
 
 extern bool dflag, pflag, sflag, uflag, gflag, Dflag, inodeflag, devflag;
 extern bool cflag, hflag, siflag, duflag, noindent;
+extern bool wcflag; // Word count flag
 
 extern const mode_t ifmt[];
 extern const char *ftype[];
@@ -94,8 +95,10 @@ void json_fillinfo(struct _info *ent)
       fprintf(outfile, ",\"size\":%lld", (long long int)ent->size);
   }
   if (Dflag) fprintf(outfile, ",\"time\":\"%s\"", do_date(cflag? ent->ctime : ent->mtime));
+  if (wcflag) {
+    fprintf(outfile, ",\"word_count\":%lld", (long long int)ent->word_count);
+  }
 }
-
 
 void json_intro(void)
 {
@@ -188,5 +191,8 @@ void json_report(struct totals tot)
   if (duflag) fprintf(outfile,",\"size\":%lld", (long long int)tot.size);
   fprintf(outfile,",\"directories\":%ld", tot.dirs);
   if (!dflag) fprintf(outfile,",\"files\":%ld", tot.files);
+  if (wcflag) {
+    fprintf(outfile,",\"total_word_count\":%lld", (long long int)tot.total_word_count);
+  }
   fprintf(outfile, "}");
 }

--- a/markdown.c
+++ b/markdown.c
@@ -1,0 +1,183 @@
+/* $Copyright: $
+ * Copyright (c) 1996 - 2024 by Steve Baker (steve.baker.llc@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+#include "tree.h"
+
+// External variables from tree.c
+extern FILE *outfile;
+extern char *_nl;
+extern bool Fflag;      // For appending file type indicators
+extern bool noreport;   // To control report generation
+extern bool duflag;     // For -du option in report
+extern bool wcflag;     // For word count in report and per-file
+extern bool noindent;   // For report formatting
+extern bool hflag, siflag; // For psize in report
+// Additional flags for metadata in markdown_printfile
+extern bool pflag, sflag, uflag, gflag, Dflag, inodeflag, devflag, cflag;
+
+// Helper function to escape Markdown special characters
+// Takes FILE* to allow flexibility, though currently uses global outfile via markdown_printfile
+static void markdown_escape_print(FILE *out_param, const char *s) {
+    if (!s) return;
+    while (*s) {
+        switch (*s) {
+            case '*': /* case '_': */ case '`': case '[': case ']': case '\\':
+            case '#': case '+': case '-': /* Period '.' is NOT escaped */ case '!':
+                fprintf(out_param, "\\%c", *s);
+                break;
+            default:
+                fprintf(out_param, "%c", *s);
+                break;
+        }
+        s++;
+    }
+}
+
+void markdown_intro(void) {
+    // No specific intro for basic Markdown list output
+    return;
+}
+
+void markdown_outtro(void) {
+    // No specific outtro for basic Markdown list output
+    return;
+}
+
+int markdown_printinfo(char *dirname, struct _info *file, int level) {
+    UNUSED(dirname);
+    UNUSED(file);
+
+    // Indentation: two spaces per level
+    if (!noindent) { // Respect noindent for the indentation part of the line
+        for (int i = 0; i < level; i++) {
+            fprintf(outfile, "  ");
+        }
+    }
+    // Markdown bullet
+    fprintf(outfile, "- ");
+    return 0; // Return 0, indicating no special closing action needed by listdir
+}
+
+int markdown_printfile(char *dirname_arg, char *filename_arg, struct _info *file, int descend) {
+    UNUSED(dirname_arg);
+    UNUSED(descend);
+
+    // Check if any metadata flag is active
+    // Ensure 'file' is not NULL before accessing its members for wcflag condition
+    bool has_meta = pflag || sflag || uflag || gflag || Dflag || inodeflag || devflag ||
+                    (wcflag && file); // Changed: show meta block if wcflag is on, regardless of count
+
+    if (has_meta && file) { // Ensure file is not NULL before trying to print metadata
+        fprintf(outfile, "[");
+        bool first_item = true;
+
+        // Helper macro to append items with a leading space if not the first item
+        #define APPEND_META_ITEM(condition, ...) \
+            if (condition) { \
+                if (!first_item) fprintf(outfile, " "); \
+                fprintf(outfile, __VA_ARGS__); \
+                first_item = false; \
+            }
+
+        if (inodeflag) APPEND_META_ITEM(true, "%lld", (long long)file->linode);
+        if (devflag) APPEND_META_ITEM(true, "%d", (int)file->ldev);
+        if (pflag) APPEND_META_ITEM(true, "%s", prot(file->mode));
+        if (uflag) APPEND_META_ITEM(true, "%s", uidtoname(file->uid));
+        if (gflag) APPEND_META_ITEM(true, "%s", gidtoname(file->gid));
+        if (sflag) {
+            char size_buf[40];
+            psize(size_buf, file->size);
+            // psize might prepend a space, remove it for cleaner look inside brackets
+            APPEND_META_ITEM(true, "%s", size_buf + (size_buf[0] == ' ' ? 1 : 0));
+        }
+        // For word count, ensure 'file' is valid. word_count is 0 for non-text files.
+        if (wcflag) { // Changed: always print word count if wcflag is on
+             APPEND_META_ITEM(true, "%lld wc", (long long)file->word_count);
+        }
+        if (Dflag) APPEND_META_ITEM(true, "%s", do_date(cflag ? file->ctime : file->mtime));
+
+        #undef APPEND_META_ITEM
+        fprintf(outfile, "] ");
+    }
+
+    // Determine the name to print: use file->name if available and not empty, otherwise filename_arg (for root dir)
+    const char *name_to_print = (file && file->name && file->name[0]) ? file->name : filename_arg;
+    markdown_escape_print(outfile, name_to_print);
+
+    if (Fflag && file) { // Append file type character if Fflag is set
+        char ftype_char = Ftype(file->mode);
+        if (ftype_char) {
+            fputc(ftype_char, outfile);
+        }
+    }
+
+    if (file && file->lnk) { // If it's a symbolic link, ensure 'file' is not NULL
+        fprintf(outfile, " -> ");
+        markdown_escape_print(outfile, file->lnk);
+        if (file->orphan) {
+            fprintf(outfile, " [orphan]");
+        }
+    }
+    return 0; // No special closing action needed by listdir
+}
+
+int markdown_error(char *error_msg) {
+    // Append error to the current line.
+    fprintf(outfile, " [Error: ");
+    markdown_escape_print(outfile, error_msg); // Use the modified escape print
+    fprintf(outfile, "]");
+    return 0;
+}
+
+void markdown_newline(struct _info *file, int level, int postdir, int needcomma) {
+    UNUSED(file);
+    UNUSED(level);
+    UNUSED(postdir);
+    UNUSED(needcomma);
+    fprintf(outfile, "%s", _nl); // _nl should be "\n" for Markdown
+}
+
+// markdown_close will use null_close from list.c, so no specific function here.
+
+void markdown_report(struct totals tot) {
+    char buf[256]; // For psize
+
+    if (noreport) {
+        return;
+    }
+
+    if (!noindent) {
+        fprintf(outfile, "\n---\n\n"); // Markdown horizontal rule and spacing
+    } else {
+        fprintf(outfile, "\n"); // Still need a newline if noindent is set
+    }
+
+    fprintf(outfile, "**Summary:**\n\n");
+
+    fprintf(outfile, "- Directories: %zu\n", tot.dirs);
+    fprintf(outfile, "- Files: %zu\n", tot.files);
+
+    if (duflag) { // duflag implies total size of dirs considered
+        psize(buf, tot.size);
+        // psize might prepend a space, adjust if necessary for cleaner Markdown.
+        fprintf(outfile, "- Total size: %s%s\n", buf + (buf[0] == ' ' ? 1 : 0), (hflag || siflag) ? "" : " bytes");
+    }
+
+    if (wcflag && (tot.dirs > 0 || tot.files > 0)) { // Only print if wcflag is on and there's something to report
+        fprintf(outfile, "- Total word count: %lld\n", (long long int)tot.total_word_count);
+    }
+}

--- a/strverscmp.c
+++ b/strverscmp.c
@@ -1,7 +1,7 @@
 /* Compare strings while treating digits characters numerically.
    Copyright (C) 1997, 2002, 2005 Free Software Foundation, Inc.
    This file is part of the libiberty library.
-   Contributed by Jean-François Bignolles <bignolle@ecoledoc.ibp.fr>, 1997.
+   Contributed by Jean-Francois Bignolles <bignolle@ecoledoc.ibp.fr>, 1997.
 
    Libiberty is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -133,7 +133,7 @@ strverscmp (const char *s1, const char *s2)
 
   while ((diff = c1 - c2) == 0 && c1 != '\0')
     {
-      state = next_state[state];
+      state = (int)next_state[state];
       c1 = *p1++;
       c2 = *p2++;
       state |= (c1 == '0') + (isdigit (c1) != 0);

--- a/tree.h
+++ b/tree.h
@@ -96,6 +96,7 @@ struct _info {
   uid_t uid;
   gid_t gid;
   off_t size;
+  off_t word_count; // Field to store word count for files/dirs
   time_t atime, ctime, mtime;
   dev_t dev, ldev;
   ino_t inode, linode;
@@ -112,6 +113,7 @@ struct _info {
 struct totals {
   size_t files, dirs;
   off_t size;
+  off_t total_word_count; // Added for word count summary
 };
 
 struct listingcalls {
@@ -266,6 +268,16 @@ int json_error(char *error);
 void json_newline(struct _info *file, int level, int postdir, int needcomma);
 void json_close(struct _info *file, int level, int needcomma);
 void json_report(struct totals tot);
+
+/* markdown.c */
+void markdown_intro(void);
+void markdown_outtro(void);
+int markdown_printinfo(char *dirname, struct _info *file, int level);
+int markdown_printfile(char *dirname, char *filename, struct _info *file, int descend);
+int markdown_error(char *error_msg);
+void markdown_newline(struct _info *file, int level, int postdir, int needcomma);
+// markdown_close will use null_close from list.c
+void markdown_report(struct totals tot);
 
 /* color.c */
 void parse_dir_colors(void);

--- a/unix.c
+++ b/unix.c
@@ -19,6 +19,7 @@
 
 extern FILE *outfile;
 extern bool dflag, Fflag, duflag, metafirst, hflag, siflag, noindent;
+extern bool wcflag; // Word count flag
 extern bool colorize, linktargetcolor, hyperflag;
 extern const struct linedraw *linedraw;
 extern int *dirs;
@@ -139,5 +140,10 @@ void unix_report(struct totals tot)
   if (dflag)
     fprintf(outfile,"%ld director%s\n",tot.dirs,(tot.dirs==1? "y":"ies"));
   else
-    fprintf(outfile,"%ld director%s, %ld file%s\n",tot.dirs,(tot.dirs==1? "y":"ies"),tot.files,(tot.files==1? "":"s"));
+	fprintf(outfile,"%ld director%s, %ld file%s",tot.dirs,(tot.dirs==1? "y":"ies"),tot.files,(tot.files==1? "":"s"));
+
+	if (wcflag) {
+	fprintf(outfile,", %lld total word%s", (long long int)tot.total_word_count, (tot.total_word_count==1?"":"s"));
+	}
+	fprintf(outfile, "\n");
 }

--- a/xml.c
+++ b/xml.c
@@ -20,6 +20,7 @@
 
 extern bool dflag, pflag, sflag, uflag, gflag;
 extern bool Dflag, inodeflag, devflag, cflag, duflag;
+extern bool wcflag; // Word count flag
 extern bool noindent;
 
 extern const char *charset;
@@ -77,6 +78,9 @@ void xml_fillinfo(struct _info *ent)
   if (gflag) fprintf(outfile, " group=\"%s\"", gidtoname(ent->gid));
   if (sflag) fprintf(outfile, " size=\"%lld\"", (long long int)(ent->size));
   if (Dflag) fprintf(outfile, " time=\"%s\"", do_date(cflag? ent->ctime : ent->mtime));
+  if (wcflag) {
+    fprintf(outfile, " word_count=\"%lld\"", (long long int)ent->word_count);
+  }
 }
 
 void xml_intro(void)
@@ -175,5 +179,8 @@ void xml_report(struct totals tot)
   if (duflag) fprintf(outfile,"%s<size>%lld</size>%s", noindent?"":"    ", (long long int)tot.size, _nl);
   fprintf(outfile,"%s<directories>%ld</directories>%s", noindent?"":"    ", tot.dirs, _nl);
   if (!dflag) fprintf(outfile,"%s<files>%ld</files>%s", noindent?"":"    ", tot.files, _nl);
+  if (wcflag) {
+    fprintf(outfile,"%s<total_word_count>%lld</total_word_count>%s", noindent?"":"    ", (long long int)tot.total_word_count, _nl);
+  }
   fprintf(outfile,"%s</report>%s",noindent?"":"  ", _nl);
 }


### PR DESCRIPTION
- Add Markdown output mode (-M).
  - Produces a standard Markdown bulleted list.
  - Uses indentation to represent tree hierarchy.
  - Compatible with metadata flags (-p, -s, -u, -g, -D, --inodes, --device).
  - Integrates with word count (-w) and size reporting (--du) in summary.
  - Mutually exclusive with XML (-X), JSON (-J), and HTML (-H) outputs.
- Add word count feature (-w).
  - Displays word count for files (heuristically skips binary files).
  - Sets word count to 0 for directories.
  - Word count info displayed in standard output and summary reports (standard, HTML, JSON, XML, Markdown).
